### PR TITLE
Fix format of dropdown link so that icon is clickable

### DIFF
--- a/Template/header/user_dropdown.php
+++ b/Template/header/user_dropdown.php
@@ -1,6 +1,5 @@
 <li>
-	<i class="fa fa-th-large fa-fw"></i> 
-    <?= $this->url->link(
+    <?= $this->url->icon('th-large',
         t('BigBoard'),
         'Bigboard',
         'index',


### PR DESCRIPTION
The icon in the user menu's entry for Bigboard isn't clickable (it doesn't take you to Bigboard, you HAVE to click the text).  This change fixes that.