### PR TITLE
Add a link to BigBoard to the dashboard menu

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -11,6 +11,7 @@ class Plugin extends Base
     {
         $this->template->hook->attach('template:project-list:menu:before', 'bigboard:Bigboard');
         $this->template->hook->attach('template:header:dropdown', 'bigboard:header/user_dropdown');
+        $this->template->hook->attach('template:dashboard:page-header:menu', 'bigboard:header/bigboard_header_link');
 
         $this->template->setTemplateOverride('board/table_container', 'bigboard:board/table_container');
         $this->template->setTemplateOverride('board/table_tasks', 'bigboard:board/table_tasks');

--- a/Template/header/bigboard_header_link.php
+++ b/Template/header/bigboard_header_link.php
@@ -1,0 +1,8 @@
+<li>
+    <?= $this->url->icon('th-large',
+        t('BigBoard'),
+        'Bigboard',
+        'index',
+        ['plugin' => 'Bigboard', ]
+    ) ?>
+</li>


### PR DESCRIPTION
I applied this change to my own KB installation, and my team appreciates that BigBoard is more visible (and just one click away) in the dashboard.