### PR TITLE
Fix switcher bar

### DIFF
--- a/Template/board/switcher.php
+++ b/Template/board/switcher.php
@@ -1,40 +1,35 @@
 <div class="table-list">
 	<div class="views-switcher-component">
-	  <ul class="input-addon no-bullet">
-		  <li class="input-addon-item">
-			  <i class="fa fa-list-ul fa-fw"></i>
-			  <?= $this->url->link(t('Project selection'), 'Bigboard', 'select', ['plugin' => 'Bigboard', 'boardview' => 'active', ], false, 'js-modal-medium') ?>
-		  </li>
-		  <li class="collapse_all input-addon-item">
-			  <span class="filter-collapse-projects">
-				  <i class="fa fa-folder-o fa-fw"></i>
-				  <a href="#" title="<?= t('Keyboard shortcut: "%s"', 'e') ?>"><?= t('Collapse all projects') ?></a>
-			  </span>
-		  </li>
-		  <li class="expand_all input-addon-item">
-			  <span class="filter-expand-projects">
-				  <i class="fa fa-folder-open-o fa-fw"></i>
-				  <a href="#" title="<?= t('Keyboard shortcut: "%s"', 'e') ?>"><?= t('Expand all projects') ?></a>
-			  </span>
-		  </li>		  
-		  <li class="input-addon-item">
-			  <span class="filter-display-mode" <?= $bigboarddisplaymode ? '' : 'style="display: none;"' ?>>
-				  <i class="fa fa-expand fa-fw"></i>
-				  <?= $this->url->link(t('Expand tasks'), 'Bigboard', 'expandAll', array('plugin' => 'Bigboard'), false, 'board-display-mode', t('Keyboard shortcut: "%s"', 's')) ?>
-			  </span>
-			  <span class="filter-display-mode" <?= $bigboarddisplaymode ? 'style="display: none;"' : '' ?>>
-				  <i class="fa fa-compress fa-fw"></i>
-				  <?= $this->url->link(t('Collapse tasks'), 'Bigboard', 'collapseAll', array('plugin' => 'Bigboard'), false, 'board-display-mode', t('Keyboard shortcut: "%s"', 's')) ?>
-			  </span>
-		  </li>
-		  <li class="input-addon-item">
-			  <span class="filter-compact">
-				  <i class="fa fa-th fa-fw"></i> <a href="#" class="filter-toggle-scrolling" title="<?= t('Keyboard shortcut: "%s"', 'c') ?>"><?= t('Compact view') ?></a>
-			  </span>
-			  <span class="filter-wide" style="display: none">
-				  <i class="fa fa-arrows-h fa-fw"></i> <a href="#" class="filter-toggle-scrolling" title="<?= t('Keyboard shortcut: "%s"', 'c') ?>"><?= t('Horizontal scrolling') ?></a>
-			  </span>
-		  </li>
-	  </ul>
+		<ul class="views">
+			<li>
+				<?= $this->url->icon('eye', t('Projects Selection'), 'Bigboard', 'select', ['plugin' => 'Bigboard', 'boardview' => 'active', ], false, 'js-modal-medium') ?>
+			</li>
+			<li class="collapse_all">
+				<a href="#"><i class="fa fa-folder-o fa-fw"></i><?= t('Collapse all projects') ?></a>
+			</li>
+			<li class="expand_all">
+				<a href="#"><i class="fa fa-folder-open-o fa-fw"></i><?= t('Expand all projects') ?></a>
+			</li>
+			<li>
+				<span class="filter-display-mode" <?= $bigboarddisplaymode ? '' : 'style="display: none;"' ?>>
+					<?= $this->url->icon('expand', t('Expand tasks'), 'Bigboard', 'expandAll', array('plugin' => 'Bigboard'), false, 'board-display-mode') ?>
+				</span>
+				<span class="filter-display-mode" <?= $bigboarddisplaymode ? 'style="display: none;"' : '' ?>>
+					<?= $this->url->icon('compress', t('Collapse tasks'), 'Bigboard', 'collapseAll', array('plugin' => 'Bigboard'), false, 'board-display-mode') ?>
+				</span>
+			</li>
+			<li>
+				<span class="filter-compact">
+					<a href="#" class="filter-toggle-scrolling" title="<?= t('Keyboard shortcut: "%s"', 'c') ?>">
+						<i class="fa fa-th fa-fw"></i><?= t('Compact view') ?>
+					</a>
+				</span>
+				<span class="filter-wide" style="display: none">
+					<a href="#" class="filter-toggle-scrolling" title="<?= t('Keyboard shortcut: "%s"', 'c') ?>">
+						<i class="fa fa-arrows-h fa-fw"></i><?= t('Horizontal scrolling') ?>
+					</a>
+				</span>
+			</li>
+		</ul>
 	</div>
 </div>


### PR DESCRIPTION
The Bigboard switcher bar has some visual issues with the Greenwing theme.  The Greenwing maintainers updated the theme to be more compatible, but Bigboard's switcher menu wasn't drawing the icons the normal Kanboard way.  I updated the switcher code.

Note about keyboard shortcuts:

- The original version of switcher.php listed keyboard shortcuts for each of the buttons (like "expand projects").
- The only keyboard shortcut that worked for me ever was 'c' to toggle collapsed/horizontal scroll modes.
- I removed references to the non-working keyboard shortcuts until that's fixed in another PR.

![01-switcher-incorrect-icons-greenwing](https://user-images.githubusercontent.com/2498295/93720383-9d1e7680-fb56-11ea-9bf7-9abb7a517e99.png)

![02-switcher-fixed-for-greenwing](https://user-images.githubusercontent.com/2498295/93720390-a576b180-fb56-11ea-886c-853a9547a071.png)
